### PR TITLE
Fix for "Invalid" appearing on maps and/or gametypes during voting

### DIFF
--- a/scripts/mapvote.gsc
+++ b/scripts/mapvote.gsc
@@ -424,6 +424,7 @@ ArrayRemoveElement(array, todelete)
 	}
 	return newarray;
 }
+
 /**
  * Selects random maps from the given list.
  *
@@ -434,6 +435,7 @@ ArrayRemoveElement(array, todelete)
 MapvoteChooseRandomMapsSelection(mapsIDsList, times) // Select random map from the list
 {
 	mapschoosed = [];
+	_mapsIDsList = mapsIDsList;
 	for (i = 0; i < times; i++)
 	{
 		index = randomIntRange(0, mapsIDsList.size);
@@ -443,8 +445,11 @@ MapvoteChooseRandomMapsSelection(mapsIDsList, times) // Select random map from t
 		if (GetDvarInt("mv_maps_norepeat"))
 		{
 			mapsIDsList = ArrayRemoveElement(mapsIDsList, map);
+			if (mapsIDsList.size == 0) 
+			{
+				mapsIDsList = _mapsIDsList;
+			}
 		}
-		// arrayremovevalue(mapsIDsList , map);
 	}
 
 	return mapschoosed;
@@ -460,6 +465,7 @@ MapvoteChooseRandomMapsSelection(mapsIDsList, times) // Select random map from t
 MapvoteChooseRandomGametypesSelection(gametypesIDsList, times) // Select random map from the list
 {
 	gametypeschoosed = [];
+	_gametypesIDsList = gametypesIDsList;
 	for (i = 0; i < times; i++)
 	{
 		index = randomIntRange(0, gametypesIDsList.size);
@@ -468,8 +474,11 @@ MapvoteChooseRandomGametypesSelection(gametypesIDsList, times) // Select random 
 		if (GetDvarInt("mv_gametypes_norepeat"))
 		{
 			gametypesIDsList = ArrayRemoveElement(gametypesIDsList, gametype);
+			if (gametypesIDsList.size == 0) 
+			{
+				gametypesIDsList = _gametypesIDsList;
+			}
 		}
-		// arrayremovevalue(mapsIDsList , map);
 	}
 
 	return gametypeschoosed;


### PR DESCRIPTION
When mv_maps_norepeat/mp_gametypes_norepeat is set, and the amount of maps/game types is less than the amount of selection options, the rest of the options show up as "Invalid".

Instead, it should cycle through the available maps/game types again.

Screenshot below shows the issue. In this example, the two selections near the end have invalid game types. This happens because the server only has 3 game types but there's 6 options.

![image](https://github.com/user-attachments/assets/d71b6797-de04-44a7-b1c1-b434d67fd315)
